### PR TITLE
Add ExtentReport API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>assertj-core</artifactId>
 			<version>3.10.0</version>
 		</dependency>
+		<dependency>
+			<groupId>com.aventstack</groupId>
+			<artifactId>extentreports</artifactId>
+			<version>3.1.5</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/geniisys/automation/common/ExtentReporter.java
+++ b/src/main/java/com/geniisys/automation/common/ExtentReporter.java
@@ -1,0 +1,96 @@
+package com.geniisys.automation.common;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.IReporter;
+import org.testng.IResultMap;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.xml.XmlSuite;
+
+import com.aventstack.extentreports.ExtentReports;
+import com.aventstack.extentreports.ExtentTest;
+import com.aventstack.extentreports.Status;
+import com.aventstack.extentreports.reporter.ExtentHtmlReporter;
+import com.aventstack.extentreports.reporter.configuration.ChartLocation;
+import com.aventstack.extentreports.reporter.configuration.Theme;
+
+public class ExtentReporter implements IReporter {
+	
+    private static final String OUTPUT_FOLDER = "C:\\SELENIUM-AUTOMATION\\REPORTS\\";
+    private static final String FILE_NAME = "ExtentReport.html";
+    
+    private ExtentReports extent;
+
+	@Override
+	public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+		init();
+
+		for (ISuite suite : suites) {
+			Map<String, ISuiteResult> result = suite.getResults();
+
+			for (ISuiteResult r : result.values()) {
+				ITestContext context = r.getTestContext();
+
+				buildTestNodes(context.getFailedTests(), Status.FAIL);
+				buildTestNodes(context.getSkippedTests(), Status.SKIP);
+				buildTestNodes(context.getPassedTests(), Status.PASS);
+
+			}
+		}
+
+		for (String s : Reporter.getOutput()) {
+			extent.setTestRunnerOutput(s);
+		}
+
+		extent.flush();
+
+	}
+
+	private void init() {
+		ExtentHtmlReporter htmlReporter = new ExtentHtmlReporter(OUTPUT_FOLDER + FILE_NAME);
+		htmlReporter.config().setDocumentTitle("ExtentReports - Geniisys Automation Testing");
+		htmlReporter.config().setReportName("ExtentReports - Geniisys Automation Testing");
+		htmlReporter.config().setTestViewChartLocation(ChartLocation.BOTTOM);
+		htmlReporter.config().setTheme(Theme.STANDARD);
+
+		extent = new ExtentReports();
+		extent.attachReporter(htmlReporter);
+		extent.setReportUsesManualConfiguration(true);
+	}
+
+	private void buildTestNodes(IResultMap tests, Status status) {
+		ExtentTest test;
+
+		if (tests.size() > 0) {
+			for (ITestResult result : tests.getAllResults()) {
+				test = extent.createTest(result.getMethod().getMethodName());
+
+				for (String group : result.getMethod().getGroups())
+					test.assignCategory(group);
+
+				if (result.getThrowable() != null) {
+					test.log(status, result.getThrowable());
+				} else {
+					test.log(status, "Test " + status.toString().toLowerCase() + "ed");
+				}
+
+				test.getModel().setStartTime(getTime(result.getStartMillis()));
+				test.getModel().setEndTime(getTime(result.getEndMillis()));
+			}
+		}
+	}
+
+	private Date getTime(long millis) {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTimeInMillis(millis);
+		return calendar.getTime();
+	}
+
+}


### PR DESCRIPTION
Added ExtentReport API to generate better TestNG reports.

To use, just add this line under `<listeners>` tag in `pom.xml`

`<listener class-name="com.geniisys.automation.common.ExtentReporter" />`

Path to generated report will be in C:\SELENIUM-AUTOMATION\REPORTS
